### PR TITLE
Added github action to create a prerelease

### DIFF
--- a/.github/workflows/esporta-pdf.yml
+++ b/.github/workflows/esporta-pdf.yml
@@ -22,3 +22,11 @@ jobs:
         with:
           name: cheatsheet
           path: cheatsheet.pdf 
+      - name: Create prerelease
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "nightly"
+          prerelease: true
+          title: "Nightly Release"
+          files: cheatsheet.pdf


### PR DESCRIPTION
La prima volta genererà un changelog infinito (vedi [qui](https://github.com/Furrrlo/ing-sw-cheatsheet/releases/tag/nightly-to-see-newly-generated-changelog)), poi si limiterà ad aggiornare con le commit correnti ([tipo qui](https://github.com/Furrrlo/ing-sw-cheatsheet/releases/tag/nightly)).

Il changelog anche volendo non si può disabilitare, ma questa era l'unica action che gestiva da sola la creazione e l'update della tag su cui fare la release 😿 